### PR TITLE
Removed the need to have the token signature to be apart of the token…

### DIFF
--- a/models/tokenRule.schema.js
+++ b/models/tokenRule.schema.js
@@ -4,6 +4,8 @@ var Schema = mongoose.Schema;
 var TokenRuleSchema = Schema({
   tag: { type: String, required: true, index: { unique: true } },
   token: { type: String, required: true },
+  tokenType: { type: String, required: true },
+  tokenValue: { type: String, required: true },
   html: { type: String, required: true },
   links: [String]
 });

--- a/util/rules.js
+++ b/util/rules.js
@@ -43,11 +43,14 @@ function getRulesFromTokens(tokens, dbTokens, dbRegex) {
   if (!tokens) {
     return rules;
   }
-
   // For each of our editor tokens...
   for (let token of tokens) {
     let tokenSig = `${token.type}:${token.value}`;  // Get the token signature
-    let found = dbTokens.find(val => val.token == tokenSig); // lets see if it's found in the tokens database
+    // let found = dbTokens.find(val => val.token == tokenSig); // lets see if it's found in the tokens database
+
+    // Find based on they token type and value
+    let found = dbTokens.find(val => val.tokenType === token.type && val.tokenValue === token.value)
+    // let found = dbTokens.find(val => val.token === tokenSig);
     if (found) {
       // In the case that there is a token of the rule... then we're good!
       rules[tokenSig] = found;  // Tack and move on to the next


### PR DESCRIPTION
… rules.

Now all that is needed is simply the token type and token value. This gets rid of redudancy and makes for better clearification. Not to mention we can target ':' now